### PR TITLE
Made the levelFill layer a sub-layer of the bodyOutline layer and the…

### DIFF
--- a/Sources/BatteryView.swift
+++ b/Sources/BatteryView.swift
@@ -79,8 +79,9 @@ open class BatteryView: UIView {
     private var levelFill = CALayer()
 
     private func setUp() {
-        layer.addSublayer(levelFill)
         layer.addSublayer(bodyOutline)
+        bodyOutline.masksToBounds = true
+        bodyOutline.addSublayer(levelFill)
         layer.addSublayer(terminalOutline)
         layer.addSublayer(terminalOpening)
         setNeedsLayout()


### PR DESCRIPTION
If you set the border radius to 1 on the Body you will see the corners of the fill sticking out of the end of the battery. 

This small change fixes that by making the the levelFill layer a sub-layer of the bodyOutline layer and then clipping the mask to avoid ever showing the fill layer outside of the outline.