### PR TITLE
Add Missing Keys to the Privacy Manifest

### DIFF
--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -4,5 +4,11 @@
 <dict>
 	<key>NSPrivacyTracking</key>
 	<false/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
 </dict>
 </plist>


### PR DESCRIPTION
These arrays are empty but this fixes the error seen when generating a privacy report for an app that imports this library.